### PR TITLE
Implement GetSharedAccessSignature and IAzureStorageFactory

### DIFF
--- a/Azure.Data.Wrappers.Test/Unit/AzureStorageTests.cs
+++ b/Azure.Data.Wrappers.Test/Unit/AzureStorageTests.cs
@@ -25,13 +25,29 @@
         [Test]
         public void ConstructorConnectionStringNull()
         {
-            Assert.That(() => new AzureStorage((string)null), Throws.TypeOf<ArgumentNullException>());
+            Assert.That(() => new AzureStorage(default(string)), Throws.TypeOf<ArgumentNullException>());
         }
 
         [Test]
         public void ConstructorAccountNull()
         {
-            Assert.That(() => new AzureStorage((CloudStorageAccount)null), Throws.TypeOf<ArgumentNullException>());
+            Assert.That(() => new AzureStorage(default(CloudStorageAccount)), Throws.TypeOf<ArgumentNullException>());
+        }
+
+        [Test]
+        public void GetSharedAccessSignatureThrowsOnNullPolicy()
+        {
+            var target = new AzureStorage(ConnectionString);
+
+            Assert.That(() => target.GetSharedAccessSignature(default(SharedAccessAccountPolicy)), Throws.TypeOf<ArgumentNullException>());
+        }
+
+        [Test]
+        public void GetSharedAccessSignatureSuccess()
+        {
+            var target = new AzureStorage(ConnectionString);
+
+            var result = target.GetSharedAccessSignature(new SharedAccessAccountPolicy());
         }
     }
 }

--- a/Azure.Data.Wrappers.Test/Unit/AzureStorageTests.cs
+++ b/Azure.Data.Wrappers.Test/Unit/AzureStorageTests.cs
@@ -48,6 +48,8 @@
             var target = new AzureStorage(ConnectionString);
 
             var result = target.GetSharedAccessSignature(new SharedAccessAccountPolicy());
+
+            Assert.IsNotNull(result);
         }
     }
 }

--- a/Azure.Data.Wrappers/AzureStorage.cs
+++ b/Azure.Data.Wrappers/AzureStorage.cs
@@ -33,7 +33,7 @@
         {
             if (null == account)
             {
-                throw new ArgumentNullException("account");
+                throw new ArgumentNullException(nameof(account));
             }
 
             this.account = account;
@@ -50,6 +50,13 @@
             {
                 return this.account;
             }
+        }
+
+        public string GetSharedAccessSignature(SharedAccessAccountPolicy policy)
+        {
+            if (policy == null) throw new ArgumentNullException(nameof(policy));
+
+            return this.account.GetSharedAccessSignature(policy);
         }
         #endregion
     }

--- a/Azure.Data.Wrappers/AzureStorageFactory.cs
+++ b/Azure.Data.Wrappers/AzureStorageFactory.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Auth;
+using Microsoft.WindowsAzure.Storage.RetryPolicies;
+
+namespace Azure.Data.Wrappers
+{
+    public class AzureStorageFactory : IAzureStorageFactory
+    {
+        public IStorageAccount GetAccount(string accountName, string key, bool useHttps)
+        {
+            if (string.IsNullOrEmpty(accountName)) throw new ArgumentNullException(nameof(accountName));
+            if (string.IsNullOrEmpty(key)) throw new ArgumentNullException(nameof(key));
+
+            return new AzureStorage(new CloudStorageAccount(new StorageCredentials(accountName, key), useHttps));
+        }
+
+        public IStorageAccount GetAccount(string connectionString)
+        {
+            if (string.IsNullOrEmpty(connectionString)) throw new ArgumentNullException(nameof(connectionString));
+
+            return new AzureStorage(connectionString);
+        }
+
+        public IStorageQueue GetAzureQueue<T>(IStorageAccount storageAccount, string queueName, int visibilityTimeoutInMS = 300000)
+        {
+            if (storageAccount == null) throw new ArgumentNullException(nameof(storageAccount));
+            if (string.IsNullOrEmpty(queueName)) throw new ArgumentNullException(nameof(queueName));
+
+            return new StorageQueue(queueName, storageAccount.Account, new TimeSpan(0, 0, 0, 0, visibilityTimeoutInMS));
+        }
+
+        public ITableStorage GetAzureTable(IStorageAccount storageAccount, string tableName)
+        {
+            if (storageAccount == null) throw new ArgumentNullException(nameof(storageAccount));
+            if (string.IsNullOrEmpty(tableName)) throw new ArgumentNullException(nameof(tableName));
+
+            return new TableStorage(tableName, storageAccount.Account);
+        }
+
+        public IContainer GetBlobFileContainer(IStorageAccount storageAccount, string containerName, bool isPublic = false, LocationMode location = LocationMode.PrimaryThenSecondary)
+        {
+            if (storageAccount == null) throw new ArgumentNullException(nameof(storageAccount));
+            if (string.IsNullOrEmpty(containerName)) throw new ArgumentNullException(nameof(containerName));
+
+            return new Container(containerName, storageAccount.Account, isPublic, location);
+        }
+    }
+}

--- a/Azure.Data.Wrappers/Interfaces.cs
+++ b/Azure.Data.Wrappers/Interfaces.cs
@@ -694,7 +694,7 @@
     }
     #endregion
 
-    #region 
+    #region IAzureStorageFactory
     public interface IAzureStorageFactory
     {
         IStorageAccount GetAccount(string accountName, string key, bool useHttps);

--- a/Azure.Data.Wrappers/Interfaces.cs
+++ b/Azure.Data.Wrappers/Interfaces.cs
@@ -25,6 +25,13 @@
             get;
         }
         #endregion
+
+        /// <summary>
+        /// Returns a shared access signature for the account.
+        /// </summary>
+        /// <param name="policy">A <see cref="SharedAccessAccountPolicy"/> object specifying the access policy for the shared access signature.</param>
+        /// <returns>A shared access signature, as a URI query string.</returns>
+        string GetSharedAccessSignature(SharedAccessAccountPolicy policy);
     }
     #endregion
 

--- a/Azure.Data.Wrappers/Interfaces.cs
+++ b/Azure.Data.Wrappers/Interfaces.cs
@@ -9,6 +9,7 @@
     using System.Collections.Generic;
     using System.IO;
     using System.Threading.Tasks;
+    using Microsoft.WindowsAzure.Storage.RetryPolicies;
 
     #region IAccount
     /// <summary>
@@ -690,6 +691,18 @@
         /// <returns>Task</returns>
         Task Delete();
         #endregion
+    }
+    #endregion
+
+    #region 
+    public interface IAzureStorageFactory
+    {
+        IStorageAccount GetAccount(string accountName, string key, bool useHttps);
+        IStorageAccount GetAccount(string connectionString);
+        IStorageQueue GetAzureQueue<T>(IStorageAccount storageAccount, string queueName, int visibilityTimeoutInMS = 300000);
+        ITableStorage GetAzureTable(IStorageAccount storageAccount, string tableName);
+        IContainer GetBlobFileContainer(IStorageAccount storageAccount, string containerName, bool isPublic = false, LocationMode location = LocationMode.PrimaryThenSecondary);
+
     }
     #endregion
 }

--- a/Azure.Data.Wrappers/Properties/AssemblyInfo.cs
+++ b/Azure.Data.Wrappers/Properties/AssemblyInfo.cs
@@ -11,5 +11,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("4e7ae8fe-0ee3-44a4-bae7-2ea46062c10e")]
-[assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.0.0")]
+[assembly: AssemblyVersion("3.1.0.0")]
+[assembly: AssemblyFileVersion("3.1.0.0")]

--- a/README.md
+++ b/README.md
@@ -2,12 +2,15 @@
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
-# Azure Storage Simplified
+# Azure Storage Simplified	
 - Queues/Blobs/Tables/File Shares
 - Azure Storage Resources
 - Dependancy Injection
 - Mockable for testing
 - Prefer async calls
+
+## Running Tests
+- execute the NUnit console runner against the test assembly
 
 # [NuGet](https://www.nuget.org/packages/Azure.Data.Wrappers)
 ```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 - Prefer async calls
 
 ## Running Tests
+- Make sure the Azure Storage Emulator is running
 - execute the NUnit console runner against the test assembly
 
 # [NuGet](https://www.nuget.org/packages/Azure.Data.Wrappers)


### PR DESCRIPTION
This change implements the GetSharedAccessSignature method on the AzureStorage class and implemnts the IAzureStorageFactory. The factory makes the wrapper a bit more testable.

I also updated the readme with some test instructions.

This change should trigger a NuGet package publish. Let me know if you would like to version differently.